### PR TITLE
Added new builtin commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(fmt)
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)
-find_package(Boost REQUIRED COMPONENTS)
+find_package(Boost REQUIRED COMPONENTS filesystem)
 
 if(Boost_FOUND)
     list(APPEND CXX_INCLUDE_DIRS ${Boost_INCLUDE_DIRS})

--- a/include/cli.h
+++ b/include/cli.h
@@ -6,7 +6,13 @@
 #include <functional>
 #include <system_error>
 
+#include "boost/filesystem.hpp"
+
 using ErrorCode = std::error_code;
+
+namespace Cli
+{
+namespace bf = boost::filesystem;
 
 class Cli
 {
@@ -16,17 +22,20 @@ class Cli
 private:
     ErrorCode cd(const std::vector<std::string>& args);
     ErrorCode exit(const std::vector<std::string>& args);
+    ErrorCode clear(const std::vector<std::string>& args);
 
 public:
     Cli(std::string_view username, std::string_view machine_name,
         std::string_view directory = "~/")
-        : m_prev_command_result(0, std::generic_category())
+        : m_path{"/bin", "/usr/bin"}
+        , m_prev_command_result(0, std::generic_category())
         , m_directory(directory)
         , m_username(username)
         , m_machine_name(machine_name)
     {
         m_builtin_commands.emplace("cd", &Cli::cd);
         m_builtin_commands.emplace("exit", &Cli::exit);
+        m_builtin_commands.emplace("clear", &Cli::clear);
     }
 
     ErrorCode run();
@@ -34,13 +43,21 @@ public:
 private:
     ErrorCode execute(const std::string& command);
 
-    [[nodiscard]] std::string advance() const;
-    void print_interface() const;
+    inline void print_interface() const;
 
+    std::vector<bf::path> m_path;
     ErrorCode m_prev_command_result;
     std::string m_directory;
     const std::string m_username;
     const std::string m_machine_name;
 
+    bool m_running = true;
+
     std::unordered_map<std::string, Command> m_builtin_commands;
 };
+
+inline ErrorCode success();
+inline ErrorCode failure();
+inline std::string advance();
+
+}

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,17 +1,18 @@
 #include <iostream>
 #include <filesystem>
-#include <sstream>
 
 #include "boost/process.hpp"
 #include "fmt/core.h"
 #include "cli.h"
 
+namespace Cli
+{
 namespace fs = std::filesystem;
 namespace bp = boost::process;
 
 ErrorCode Cli::run()
 {
-    while (true)
+    while (m_running)
     {
         m_directory = fs::current_path().string();
         print_interface();
@@ -21,31 +22,45 @@ ErrorCode Cli::run()
 
         std::cout << "\n";
     }
+
+    return success();
 }
 
 ErrorCode Cli::execute(const std::string& command)
 {
     const std::string& binary = command.substr(0, command.find(' '));
 
-    if (m_builtin_commands.contains(binary))
+    // Extract arguments.
+    std::vector<std::string> args;
+
+    size_t arg_start_indx = command.find(' ');
+    if (arg_start_indx != std::string::npos)
     {
-        // Extract arguments.
         std::stringstream stream{command.substr(command.find(' '))};
         std::string argument;
-        std::vector<std::string> args;
 
         while (stream.good())
         {
             stream >> argument;
             args.emplace_back(argument);
         }
+    }
 
+    if (m_builtin_commands.contains(binary))
+    {
         return m_builtin_commands[binary](this, args);
     }
 
     try
     {
-        bp::child process{command};
+        bf::path path_to_binary = bp::search_path(binary, m_path);
+        if (path_to_binary.empty())
+        {
+            fmt::print("Failed to find command '{}'.\n", binary);
+            return failure();
+        }
+
+        bp::child process{path_to_binary, args};
         process.wait();
         return ErrorCode{process.exit_code(), std::system_category()};
     }
@@ -56,14 +71,7 @@ ErrorCode Cli::execute(const std::string& command)
     }
 }
 
-std::string Cli::advance() const
-{
-    std::string command;
-    std::getline(std::cin, command);
-    return command;
-}
-
-void Cli::print_interface() const
+inline void Cli::print_interface() const
 {
     fmt::print("{}@{}: {}> [{}] ", m_username, m_machine_name, m_directory,
                m_prev_command_result.value());
@@ -71,37 +79,73 @@ void Cli::print_interface() const
 
 ErrorCode Cli::cd(const std::vector<std::string>& args)
 {
-    // `cd` receives only 1 argument.
-    assert(args.size() == 1);
+    if (args.size() != 1)
+    {
+        fmt::print("usage: cd [path_to_directory]\n");
+        return failure();
+    }
 
-    int result = chdir(args[0].c_str());
+    std::string_view path = args[0];
+
+    if (path == "~")
+    {
+        path = "/home/" + m_username;
+    }
+
+    int result = chdir(path.data());
     if (result != 0)
     {
         switch (errno)
         {
             case EACCES:
-                fmt::print("Permission denied.");
+                fmt::print("Permission denied.\n");
                 break;
             case ENAMETOOLONG:
-                fmt::print("The path was to long.");
+                fmt::print("The path was to long.\n");
                 break;
             case ENOENT:
-                fmt::print("The path does not exist.");
+                fmt::print("The path does not exist.\n");
                 break;
             case ENOTDIR:
-                fmt::print("The path is not a directory.");
+                fmt::print("The path is not a directory.\n");
                 break;
             default:
-                fmt::print("Not every error case was handled: {}.", errno);
+                fmt::print("Not every error case was handled: {}.\n", errno);
                 break;
         }
         return ErrorCode(errno, std::system_category());
     }
 
-    return ErrorCode(0, std::generic_category());
+    return success();
 }
 
 ErrorCode Cli::exit(const std::vector<std::string>& args)
 {
-    return ErrorCode();
+    m_running = false;
+    return success();
+}
+
+ErrorCode Cli::clear(const std::vector<std::string>& args)
+{
+    bp::system("clear");
+    return success();
+}
+
+inline ErrorCode success()
+{
+    return ErrorCode(0, std::generic_category());
+}
+
+inline ErrorCode failure()
+{
+    return ErrorCode(1, std::generic_category());
+}
+
+inline std::string advance()
+{
+    std::string command;
+    std::getline(std::cin, command);
+    return command;
+}
+
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 
 int main()
 {
-    Cli cli{"azamat", "aza_machine"};
+    Cli::Cli cli{"azamat", "aza_machine"};
 
     return cli.run().value();
 }


### PR DESCRIPTION
Added `exit` and `clear` commands.
Added the PATH variable (you can't change it yet though :D).
`cd ~` now takes you to your home directory.
The shell no longer crashes when you pass wrong number of arguments to
`cd`.
`ErrorCode` constructors are replaced with utility `success()` and
`failure()` functions.