### PR TITLE
Added environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 ## shell
 
 A basic UNIX-like shell.
+
+## Dependencies
+
+- [{fmt}](https://github.com/fmtlib/fmt) - a modern formatting library.
+- [Boost.Process](https://www.boost.org/doc/libs/1_76_0/doc/html/process.html) - a Boost library that is used for 
+  spawning external processes and the communication between them.
+- [Boost.Filesystem](https://www.boost.org/doc/libs/1_69_0/libs/filesystem/doc/index.htm) - 
+    `boost::process::child` constructor does not support `std::filesystem::path`. So I had to use this library to 
+    obtain compatible paths.
+
+Only Linux is supported.
+
+## Build
+
+1. `mkdir build`
+2. `cd build`
+3. `cmake ..`
+4. `make`
+
+## Usage
+
+`cli [username] [machine name]`

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,15 @@
 #include "cli.h"
+#include <fmt/core.h>
 
-int main()
+int main(int argc, char** argv)
 {
-    Cli::Cli cli{"azamat", "aza_machine"};
+    if (argc != 3)
+    {
+        fmt::print("usage: cli [username] [machine name]\n");
+        return EXIT_FAILURE;
+    }
+
+    Cli::Cli cli{argv[1], argv[2]};
 
     return cli.run().value();
 }


### PR DESCRIPTION
You can now add variables (`export`) and the shell can resolve them.
Added `echo` command that acts as every other `echo`.
Added `-s` argument to `path` command, that prints the PATH contents.
Added an argument check in `main.cpp`.
Updated README.md.
Moved PATH-updating code into a new method.
Added additional check to ensure the correct use of `>` and `|`.
Added `noexcept` to some methods.